### PR TITLE
Hourly Stats

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ use Mix.Config
 # Configures bitfeels application
 config :bitfeels, :twitter_stream,
   tweet_sink: SenTweet.Bitfeels,
-  metric_sink: SenTweet.Metrics
+  metric_sink: SenTweet.Reporter
 
 config :bitfeels, :sentiment,
   url: "http://0.0.0.0:5000/score",

--- a/lib/sen_tweet/application.ex
+++ b/lib/sen_tweet/application.ex
@@ -14,7 +14,9 @@ defmodule SenTweet.Application do
       # Start bitfeels twitter stream worker
       {SenTweet.Bitfeels, []},
       # Start bitfeels metric server
-      {SenTweet.Bitfeels.MetricServer, []}
+      {SenTweet.Bitfeels.MetricServer, []},
+      # Start bitfeels hourly statistics server
+      {SenTweet.Bitfeels.HourlyStats, []}
     ]
 
     opts = [strategy: :one_for_one, name: SenTweet.Supervisor]

--- a/lib/sen_tweet/bitfeels/events.ex
+++ b/lib/sen_tweet/bitfeels/events.ex
@@ -1,5 +1,4 @@
 defmodule SenTweet.Bitfeels.Events do
-
   alias SenTweet.Bitfeels.{Stats, HourlyStats}
 
   def handle_event([:bitfeels, :pipeline, :sentiment], %{score: score} = measurements, metadata)

--- a/lib/sen_tweet/bitfeels/events.ex
+++ b/lib/sen_tweet/bitfeels/events.ex
@@ -1,0 +1,17 @@
+defmodule SenTweet.Bitfeels.Events do
+
+  alias SenTweet.Bitfeels.{Stats, HourlyStats}
+
+  def handle_event([:bitfeels, :pipeline, :sentiment], %{score: score} = measurements, metadata)
+      when is_float(score) do
+    metadata
+    |> HourlyStats.get()
+    |> Stats.update_score(measurements, metadata)
+    |> Stats.update_metadata(measurements, metadata)
+    |> HourlyStats.put(metadata)
+  end
+
+  def handle_event(_event, _measurements, _metadata) do
+    %{}
+  end
+end

--- a/lib/sen_tweet/bitfeels/events.ex
+++ b/lib/sen_tweet/bitfeels/events.ex
@@ -1,5 +1,8 @@
 defmodule SenTweet.Bitfeels.Events do
-  alias SenTweet.Bitfeels.{Stats, HourlyStats}
+  @moduledoc """
+  Handle incoming events emitted from the bitfeels application
+  """
+  alias SenTweet.Bitfeels.{HourlyStats, Stats}
 
   def handle_event([:bitfeels, :pipeline, :sentiment], %{score: score} = measurements, metadata)
       when is_float(score) do

--- a/lib/sen_tweet/bitfeels/hourly_stats.ex
+++ b/lib/sen_tweet/bitfeels/hourly_stats.ex
@@ -12,7 +12,7 @@ defmodule SenTweet.Bitfeels.HourlyStats do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  def all() do
+  def all do
     GenServer.call(__MODULE__, :all)
   end
 
@@ -58,7 +58,7 @@ defmodule SenTweet.Bitfeels.HourlyStats do
     "#{user}_#{track}"
   end
 
-  defp current_hour() do
+  defp current_hour do
     time = Time.utc_now()
     time.hour
   end

--- a/lib/sen_tweet/bitfeels/hourly_stats.ex
+++ b/lib/sen_tweet/bitfeels/hourly_stats.ex
@@ -1,0 +1,74 @@
+defmodule SenTweet.Bitfeels.HourlyStats do
+  @moduledoc """
+  Process that manages hourly statistics for bitfeels
+  """
+  use GenServer
+
+  alias SenTweet.Bitfeels.Stats
+
+  # Client
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def all() do
+    GenServer.call(__MODULE__, :all)
+  end
+
+  def get(metadata) do
+    GenServer.call(__MODULE__, {:get, metadata})
+  end
+
+  def put(stats, metadata) do
+    GenServer.call(__MODULE__, {:put, stats, metadata})
+  end
+
+  # Server
+
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  def handle_call(:all, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call({:get, metadata}, _from, state) do
+    stream_key = stream_key(metadata)
+    current_hour = current_hour()
+    hourly_stats = get_hourly_stats(state[stream_key], current_hour)
+
+    {:reply, hourly_stats[current_hour], %{stream_key => hourly_stats}}
+  end
+
+  def handle_call({:put, stats, metadata}, _from, state) do
+    stream_key = stream_key(metadata)
+    current_hour = current_hour()
+    hourly_stats =
+      state[stream_key] |> get_hourly_stats(current_hour) |> Map.put(current_hour, stats)
+
+    {:reply, hourly_stats[current_hour], %{stream_key => hourly_stats}}
+  end
+
+  # Helper functions
+
+  defp stream_key(%{user: user, track: track}) do
+    "#{user}_#{track}"
+  end
+
+  defp current_hour() do
+    time = Time.utc_now()
+    time.hour
+  end
+
+  defp get_hourly_stats(nil, current_hour), do: %{current_hour => Stats.create()}
+
+  defp get_hourly_stats(hourly_stats, current_hour) do
+    case hourly_stats do
+      %{^current_hour => _} -> hourly_stats
+
+      _new_hour -> Map.put(hourly_stats, current_hour, Stats.create())
+    end
+  end
+end

--- a/lib/sen_tweet/bitfeels/hourly_stats.ex
+++ b/lib/sen_tweet/bitfeels/hourly_stats.ex
@@ -45,6 +45,7 @@ defmodule SenTweet.Bitfeels.HourlyStats do
   def handle_call({:put, stats, metadata}, _from, state) do
     stream_key = stream_key(metadata)
     current_hour = current_hour()
+
     hourly_stats =
       state[stream_key] |> get_hourly_stats(current_hour) |> Map.put(current_hour, stats)
 
@@ -67,7 +68,6 @@ defmodule SenTweet.Bitfeels.HourlyStats do
   defp get_hourly_stats(hourly_stats, current_hour) do
     case hourly_stats do
       %{^current_hour => _} -> hourly_stats
-
       _new_hour -> Map.put(hourly_stats, current_hour, Stats.create())
     end
   end

--- a/lib/sen_tweet/bitfeels/metrics.ex
+++ b/lib/sen_tweet/bitfeels/metrics.ex
@@ -8,7 +8,7 @@ defmodule SenTweet.Bitfeels.Metrics do
   alias SenTweetWeb.MetricChannel
 
   def create_metrics do
-    Stats.create_stats()
+    Stats.create()
   end
 
   def handle_event([:bitfeels, :pipeline, :source], _measurements, metadata) do
@@ -19,10 +19,8 @@ defmodule SenTweet.Bitfeels.Metrics do
       when is_float(score) do
     metadata
     |> MetricServer.get_metrics()
-    |> Stats.update_all_stats(measurements, metadata)
-    |> Map.put(:user, metadata.user)
-    |> Map.put(:track, metadata.track)
-    |> Map.put(:last_metric_at, measurements.time)
+    |> Stats.update_score(measurements, metadata)
+    |> Stats.update_metadata(measurements, metadata)
     |> MetricServer.update_metrics(metadata)
     |> MetricChannel.broadcast_metrics()
   end

--- a/lib/sen_tweet/bitfeels/stats.ex
+++ b/lib/sen_tweet/bitfeels/stats.ex
@@ -6,7 +6,7 @@ defmodule SenTweet.Bitfeels.Stats do
   @tweet_types [:extended_tweet, :retweeted_status, :quoted_status, :text]
   @weight_factors [:tweets, :likes, :retweets]
 
-  def create() do
+  def create do
     for type <- @tweet_types, into: %{}, do: {type, empty_stats()}
   end
 

--- a/lib/sen_tweet/bitfeels/stats.ex
+++ b/lib/sen_tweet/bitfeels/stats.ex
@@ -6,17 +6,21 @@ defmodule SenTweet.Bitfeels.Stats do
   @tweet_types [:extended_tweet, :retweeted_status, :quoted_status, :text]
   @weight_factors [:tweets, :likes, :retweets]
 
-  def create_stats do
+  def create() do
     for type <- @tweet_types, into: %{}, do: {type, empty_stats()}
   end
 
-  def update_all_stats(all_stats, measurements, %{tweet_type: type} = metadata) do
+  def update_score(stats, measurements, %{tweet_type: type} = metadata) do
     type = String.to_existing_atom(type)
 
-    %{
-      all_stats
-      | type => update_type_stats(all_stats[type], measurements.score, metadata)
-    }
+    %{stats | type => update_type_stats(stats[type], measurements.score, metadata)}
+  end
+
+  def update_metadata(stats, measurements, metadata) do
+    stats
+    |> Map.put(:user, metadata.user)
+    |> Map.put(:track, metadata.track)
+    |> Map.put(:last_metric_at, measurements.time)
   end
 
   defp update_type_stats(type_stats, score, metadata) do

--- a/lib/sen_tweet/reporter.ex
+++ b/lib/sen_tweet/reporter.ex
@@ -1,4 +1,4 @@
-defmodule SenTweet.Metrics do
+defmodule SenTweet.Reporter do
   @moduledoc """
   Reporter module for handling individual events
 
@@ -41,6 +41,7 @@ defmodule SenTweet.Metrics do
 
   defp handle_event([:bitfeels | _] = event_name, measurements, metadata, _metrics) do
     Bitfeels.Metrics.handle_event(event_name, measurements, metadata)
+    Bitfeels.Events.handle_event(event_name, measurements, metadata)
   end
 
   defp handle_event(_event_name, _measurements, _metadata, _metrics) do

--- a/lib/sen_tweet_web/telemetry.ex
+++ b/lib/sen_tweet_web/telemetry.ex
@@ -22,7 +22,7 @@ defmodule SenTweetWeb.Telemetry do
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
       # Add reporters as children of your supervision tree.
-      {SenTweet.Metrics, metrics: metrics()}
+      {SenTweet.Reporter, metrics: metrics()}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SenTweet.MixProject do
   use Mix.Project
 
-  @version "1.1.15"
+  @version "1.1.16"
 
   def project do
     [


### PR DESCRIPTION
1 of 3 for ref #41 

This PR adds the `HourlyStats` server which holds stats for every hour in the day. UTC time is used so we have a 0-23 set of `current_hour` keys.

For now this will run in conjunction with the existing metric server. I added another event handler to accomplish this, `Bitfeels.Events.handle_event/3`

Easiest way to test is to let in the run in production for one day then call `SenTweet.Bitfeels.HourlyStats.all()` and see that we have 24 entires.